### PR TITLE
Fix Build Error with Publish v0.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 /**
 *  StrongTypedCSS plugin for Publish
@@ -10,6 +10,7 @@ import PackageDescription
 
 let package = Package(
     name: "StrongTypedCSSPublishPlugin",
+    platforms: [.macOS(.v12)],
     products: [
         .library(
             name: "StrongTypedCSSPublishPlugin",
@@ -21,7 +22,7 @@ let package = Package(
     targets: [
         .target(
             name: "StrongTypedCSSPublishPlugin",
-            dependencies: ["Publish"]),
+            dependencies: [.product(name: "Publish", package: "publish")]),
         .testTarget(
             name: "StrongTypedCSSPublishPluginTests",
             dependencies: ["StrongTypedCSSPublishPlugin"]),


### PR DESCRIPTION
Bumps `swift-tools-version` to `5.5` and require macOS 12.0.

Publish [0.9.0](https://github.com/JohnSundell/Publish/releases/tag/0.9.0) requires Swift 5.5 and macOS 12.0 Monterey. Attempting to build a package using the latest version of Publish and this plugin fails with the following error:

```
The package product 'Publish' requires minimum platform version 12.0 for the macOS platform, but this target supports 10.13
```

This change fixes that.